### PR TITLE
exposed include paths

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,8 @@ No configuration is required, it will compile the files implicitly on project bu
   <DartSassOutputLevel>verbose</DartSassOutputLevel>
   <!-- msbuild output level -->
   <DartSassMessageLevel>High</DartSassMessageLevel>
+  <!-- include paths for imports -->
+  <DartSassIncludePaths>node_modules</DartSassIncludePaths>
 </PropertyGroup>
 ```
 
@@ -84,13 +86,15 @@ dsb help files
 Scans a directory recursively to generate .css files
 
 ```
--e, --exclude    (Default: bin obj logs node_modules) Specify explicit directories to exclude. Overrides the default.
+-e, --exclude          (Default: bin obj logs node_modules) Specify explicit directories to exclude. Overrides the default.
 
---help           Display this help screen.
+-i, --include-paths    (Default: node_modules) List of paths that library can look in to attempt to resolve @import declarations. Overrides the default.
 
---version        Display version information.
+--help                 Display this help screen.
 
-value pos. 0     Directory in which to run. Defaults to current directory.
+--version              Display version information.
+
+value pos. 0           Directory in which to run. Defaults to current directory.
 ```
 
 Example:
@@ -113,11 +117,13 @@ Files in the following directories are excluded by default:
 Processes the files given on the commandline
 
 ```
---help           Display this help screen.
+-i, --include-paths    (Default: node_modules) List of paths that library can look in to attempt to resolve @import declarations. Overrides the default.
 
---version        Display version information.
+--help                 Display this help screen.
 
-value pos. 0     File(s) to process.
+--version              Display version information.
+
+value pos. 0           File(s) to process.
 ```
 
 Example:

--- a/package/build/DartSassBuilder.targets
+++ b/package/build/DartSassBuilder.targets
@@ -72,8 +72,11 @@
           BeforeTargets="BeforeBuild"  
           Condition="'$(_DartSassHashChanged)-$(DartSassShouldBuildBasedOnSassFiles)' == 'true-true' ">
     <PropertyGroup>
+      <DartSassBuilderArgs>$(DartSassBuilderArgs) --outputstyle $(DartSassOutputStyle)</DartSassBuilderArgs>
+      <DartSassBuilderArgs>$(DartSassBuilderArgs) --level $(DartSassOutputLevel)</DartSassBuilderArgs>
+      <DartSassBuilderArgs Condition=" '$(DartSassIncludePaths)'!='' ">$(DartSassBuilderArgs) --include-paths $([System.String]::Copy('$(DartSassIncludePaths)').Replace(';', ' '))</DartSassBuilderArgs>
       <_SassFileList>@(SassFilesToCompile->'&quot;%(FullPath)&quot;', ' ')</_SassFileList> <!-- all valid files, space seperated, surrounded with quotes -->
-      <DartSassBuilderArgs>files $(_SassFileList) --outputstyle $(DartSassOutputStyle) --level $(DartSassOutputLevel)</DartSassBuilderArgs>
+      <DartSassBuilderArgs>files $(_SassFileList)$(DartSassBuilderArgs)</DartSassBuilderArgs>
     </PropertyGroup>
     <Message Text="Converted SassFile list to argument" Importance="$(DartSassMessageLevel)" />
   </Target>

--- a/src/DartSassBuilder/GenericOptions.cs
+++ b/src/DartSassBuilder/GenericOptions.cs
@@ -1,4 +1,5 @@
-﻿using CommandLine;
+﻿using System.Collections.Generic;
+using CommandLine;
 using DartSassHost;
 
 namespace DartSassBuilder
@@ -7,6 +8,9 @@ namespace DartSassBuilder
     {
         [Option('l', "level", Required = false, HelpText = "Specify the level of output (silent, default, verbose)")]
         public OutputLevel OutputLevel { get; set; } = OutputLevel.Default;
+
+        [Option('i', "include-paths", Required = false, HelpText = "List of paths that library can look in to attempt to resolve @import declarations. Overrides the default.", Default = new[] { "node_modules" })]
+        public IEnumerable<string> IncludePaths { get; set; }
 
         public CompilationOptions SassCompilationOptions { get; } = new CompilationOptions()
         {

--- a/src/DartSassBuilder/Program.cs
+++ b/src/DartSassBuilder/Program.cs
@@ -59,6 +59,10 @@ namespace DartSassBuilder
         public Program(GenericOptions options)
         {
             Options = options;
+            if (Options.IncludePaths != null)
+            {
+                Options.SassCompilationOptions.IncludePaths = Options.IncludePaths.ToList();
+            }
         }
 
         async Task CompileDirectoriesAsync(string directory, IEnumerable<string> excludedDirectories)


### PR DESCRIPTION
Paths can be delimited by ` ` or `;` in the msbuild property.
Defaulted the include paths to the common one I use, `node_modules`.

Grabbing the nuget cache paths for referenced packages such as like `bootstrap.sass` would be a nice to have, and seems like a possibility, but would require more research on my part.

Should resolve https://github.com/deanwiseman/DartSassBuilder/issues/20