### PR TITLE
Update a Dart Sass Host to version 1.0.1

### DIFF
--- a/src/DartSassBuilder/DartSassBuilder.csproj
+++ b/src/DartSassBuilder/DartSassBuilder.csproj
@@ -19,12 +19,12 @@
 
 	<ItemGroup>
 		<PackageReference Include="CommandLineParser" Version="2.8.0" />
-		<PackageReference Include="DartSassHost" Version="1.0.0-preview7" />
-		<PackageReference Include="JavaScriptEngineSwitcher.V8" Version="3.17.3" />
-		<PackageReference Include="Microsoft.ClearScript.V8.Native.linux-x64" Version="7.2.3" />
-		<PackageReference Include="Microsoft.ClearScript.V8.Native.osx-x64" Version="7.2.3" />
-		<PackageReference Include="Microsoft.ClearScript.V8.Native.osx-arm64" Version="7.2.3" />
-		<PackageReference Include="Microsoft.ClearScript.V8.Native.win-x64" Version="7.2.3" />
+		<PackageReference Include="DartSassHost" Version="1.0.1" />
+		<PackageReference Include="JavaScriptEngineSwitcher.V8" Version="3.20.8" />
+		<PackageReference Include="Microsoft.ClearScript.V8.Native.linux-x64" Version="7.3.6" />
+		<PackageReference Include="Microsoft.ClearScript.V8.Native.osx-x64" Version="7.3.6" />
+		<PackageReference Include="Microsoft.ClearScript.V8.Native.osx-arm64" Version="7.3.6" />
+		<PackageReference Include="Microsoft.ClearScript.V8.Native.win-x64" Version="7.3.6" />
 	</ItemGroup>
 
 	<ItemGroup>


### PR DESCRIPTION
Hello, Dean!

Dart Sass Host library has recently become stable, so I recommend that you update it, as well as its dependencies, to the latest versions.